### PR TITLE
fix: No css on docker container build by GH Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "react-dom": "18.3.1",
     "react-router": "7.6.1",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss": "^4.1.12"
+    "tailwindcss": "^4.0.8"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "4.1.12",
+    "@tailwindcss/vite": "4.0.8",
     "@babel/preset-react": "7.27.1",
     "@preact/signals-react-transform": "0.5.1",
     "@rollup/plugin-replace": "6.0.2",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,18 @@ const customConfig: UserConfigFn = (env) => ({
             "@": path.resolve(__dirname, "./src/main/frontend"),
         },
     },
+    logLevel: env.mode === 'production' ? 'info' : 'info',
+    css: {
+        postcss: {}
+    },
+    build: {
+        reportCompressedSize: false,
+        rollupOptions: {
+            output: {
+                manualChunks: undefined,
+            }
+        }
+    },
 });
 
 export default overrideVaadinConfig(customConfig);


### PR DESCRIPTION
Lorsqu'un container est build en locale, celui-ci fonctionne parfaitement mais dès que celui-ci est construit par github action, tailwindcss ne génère aucun css dans le .jar